### PR TITLE
Update readme for installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Build with Visual Studio 2015. May build with other compilers, but not tested
 Download [SDL2-devel-2.0.4-VC.zip](https://www.libsdl.org/release/SDL2-devel-2.0.4-VC.zip), extract and
 copy SDL2-2.0.4\lib\x64\SDL2.lib to C:\Rust\lib\rustlib\x86_64-pc-windows-msvc\lib\SDL2.lib.
 
+## Running
 
 ### Standalone
 

--- a/README.md
+++ b/README.md
@@ -17,113 +17,73 @@ In action: http://gfycat.com/NeedyElaborateGypsymoth
 I generally am on the `irc.spi.gt` irc network in the `#think` channel.
 Feel free to pop in to say hi, [Webchat can be found here](https://irc.spi.gt/iris/?channels=think)
 
-## Building
-# Table of contents
-* [Prerequisites](#prerequisites)
-* [Compiling on OS X](#compiling-on-os-x)
-* [Compiling on Linux](#compiling-on-linux)
-* [Compiling on Windows](#compiling-on-windows)
-
-# Prerequisites
-
-Compiling `steven-rust` requires a working rust nightly installation, openssl and sdl2. Instructions for setting up openssl and sdl2 are platform-specific and will be covered as such outside of this section. 
-
-An easy way to manage multiple Rust toolchains is [`rustup`](https://github.com/rust-lang-nursery/rustup.rs). Installation instructions for `rustup` can be found on its [website](https://www.rustup.rs/).
-
-Once you've set up `rustup`, grab rust nightly by running
-```sh
-rustup install nightly
-```
-
-Now we need to make sure that `steven-rust` is compiled with nightly. To do this without making nightly the default across the entire system, run the following command in the `steven-rust` directory:
-```sh
-rustup override set nightly
-```
-
-# Compiling on Linux
-
-## Installing dependencies
-
-Install openssl and sdl2 (with headers) via your distro's package manager. (Packages with headers generally end with `-dev`)
-
-## Compiling
-Compile and run:
-```bash
-cargo run --release
-```
-Just compile:
-```bash
-cargo build --release
-```
-# Compiling on OS X
-## Installing dependencies
-Installing them is easiest with [homebrew](http://brew.sh/).
-
-To install openssl and sdl2 issue these commands:
-```bash
-brew install sdl2
-brew install openssl
-```
-Older versions of OS X come with an older version of openssl while El Capitan and newer do not come with it at all. Compiling `steven-rust` with older OS X versions would most likely work without installing the openssl library (and using the OPENSSL_ environment variables), but I would recommend installing it anyway.
-### TODO: Instructions without homebrew
-## Compiling
-To compile `steven-rust` you can use this simple bash script to set the environment variables so the compiler can find the required libraries.
-```bash
-#!/bin/bash
-export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/lib"
-export OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include
-export OPENSSL_LIB_DIR=`brew --prefix openssl`/lib
-cargo "$@"
-```
-
-Compile and run:
-```bash
-./scriptname.sh run --release
-```
-
-Just compile:
-```bash
-./scriptname.sh build --release
-```
-
-Alternatively you can skip the script and add the variables directly to the command:
-```bash
-LIBRARY_PATH="$LIBRARY_PATH:/usr/local/lib" OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include OPENSSL_LIB_DIR=`brew --prefix openssl`/lib cargo build --release
-```
-Note: If you're not using `homebrew` you probably don't need to set the environment variables.
-
-# Compiling on Windows
-
-Note: Make sure that you have the rust nightly GNU ABI toolchain installed with rustup rather than the MSVC ABI. You can check this by running `rustup show` and ensure that you grab the GNU ABI toolchain with `rustup install nightly-gnu`
-
-## Installing dependencies
-Follow the instructions at https://msys2.github.io to install `msys` and `mingw`. After that, run the following command from `msys`:
-```bash
-pacman -S git tar mingw-w64-x86_64-openssl mingw-w64-x86_64-SDL2 mingw-w64-x86_64-gcc
-```
-
-## Compiling
-Compile and run:
-```bash
-cargo run --release
-```
-Just compile:
-```bash
-cargo build --release
-```
-
-
-
-Currently requires SDL2, and **beta or nightly** Rust to build.
-
-`cargo build --release`
+## Downloads
 
 Windows users can download pre-compiled builds from here: https://ci.appveyor.com/project/iceiix/steven
 (Select your platform, Click the artifacts tab and download Steven.zip)
 
 The Visual Studio 2015 Redistributable is required to run these builds.
 
-## Running
+## Building
+
+Currently requires SDL2, and **beta or nightly** Rust to build.
+
+Compile and run:
+```bash
+cargo run --release
+```
+Just compile:
+```bash
+cargo build --release
+```
+
+If you get an error such as:
+
+```
+  = note: ld: library not found for -lSDL2                                                                                                                                                                                                   
+          clang: error: linker command failed with exit code 1 (use -v to see invocation)     
+```
+
+then you need to install the prerequisites, see below:
+
+### Prerequisites
+
+Compiling `steven` requires Rust beta and SDL2. Instructions for setting up SDL2 is platform-specific and will be covered as such outside of this section. 
+
+An easy way to manage multiple Rust toolchains is [`rustup`](https://github.com/rust-lang-nursery/rustup.rs). Installation instructions for `rustup` can be found on its [website](https://www.rustup.rs/).
+
+Once you've set up `rustup`, grab Rust beta by running
+```sh
+rustup install beta
+```
+
+Now we need to make sure that `steven` is compiled with beta. To do this without making beta the default across the entire system, run the following command in the `steven` directory:
+```sh
+rustup override set beta
+```
+
+### Installing dependencies on Linux
+Install SDL2 (with headers) via your distro's package manager. Packages with headers generally end with `-dev`.
+For example on Debian-based systems such as Ubuntu Linux:
+
+```bash
+apt-get install -y libsdl2-dev libsdl2-mixer-dev gcc libegl1-mesa-dev libgles2-mesa-dev
+```
+
+### Installing dependencies on OS X
+Installing them is easiest with [Homebrew](http://brew.sh/). To install SDL2 issue this command:
+
+```bash
+brew install sdl2
+```
+
+### Installing dependencies on Windows
+Build with Visual Studio 2015. May build with other compilers, but not tested
+(previously was built with MinGW and the GNU toolchain).
+
+Download [SDL2-devel-2.0.4-VC.zip](https://www.libsdl.org/release/SDL2-devel-2.0.4-VC.zip), extract and
+copy SDL2-2.0.4\lib\x64\SDL2.lib to C:\Rust\lib\rustlib\x86_64-pc-windows-msvc\lib\SDL2.lib.
+
 
 ### Standalone
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,101 @@ I generally am on the `irc.spi.gt` irc network in the `#think` channel.
 Feel free to pop in to say hi, [Webchat can be found here](https://irc.spi.gt/iris/?channels=think)
 
 ## Building
-For more detailed info and platform specific instructions check the [wiki](https://github.com/Thinkofname/steven-rust/wiki/Compiling-and-or-running).
+# Table of contents
+* [Prerequisites](#prerequisites)
+* [Compiling on OS X](#compiling-on-os-x)
+* [Compiling on Linux](#compiling-on-linux)
+* [Compiling on Windows](#compiling-on-windows)
+
+# Prerequisites
+
+Compiling `steven-rust` requires a working rust nightly installation, openssl and sdl2. Instructions for setting up openssl and sdl2 are platform-specific and will be covered as such outside of this section. 
+
+An easy way to manage multiple Rust toolchains is [`rustup`](https://github.com/rust-lang-nursery/rustup.rs). Installation instructions for `rustup` can be found on its [website](https://www.rustup.rs/).
+
+Once you've set up `rustup`, grab rust nightly by running
+```sh
+rustup install nightly
+```
+
+Now we need to make sure that `steven-rust` is compiled with nightly. To do this without making nightly the default across the entire system, run the following command in the `steven-rust` directory:
+```sh
+rustup override set nightly
+```
+
+# Compiling on Linux
+
+## Installing dependencies
+
+Install openssl and sdl2 (with headers) via your distro's package manager. (Packages with headers generally end with `-dev`)
+
+## Compiling
+Compile and run:
+```bash
+cargo run --release
+```
+Just compile:
+```bash
+cargo build --release
+```
+# Compiling on OS X
+## Installing dependencies
+Installing them is easiest with [homebrew](http://brew.sh/).
+
+To install openssl and sdl2 issue these commands:
+```bash
+brew install sdl2
+brew install openssl
+```
+Older versions of OS X come with an older version of openssl while El Capitan and newer do not come with it at all. Compiling `steven-rust` with older OS X versions would most likely work without installing the openssl library (and using the OPENSSL_ environment variables), but I would recommend installing it anyway.
+### TODO: Instructions without homebrew
+## Compiling
+To compile `steven-rust` you can use this simple bash script to set the environment variables so the compiler can find the required libraries.
+```bash
+#!/bin/bash
+export LIBRARY_PATH="$LIBRARY_PATH:/usr/local/lib"
+export OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include
+export OPENSSL_LIB_DIR=`brew --prefix openssl`/lib
+cargo "$@"
+```
+
+Compile and run:
+```bash
+./scriptname.sh run --release
+```
+
+Just compile:
+```bash
+./scriptname.sh build --release
+```
+
+Alternatively you can skip the script and add the variables directly to the command:
+```bash
+LIBRARY_PATH="$LIBRARY_PATH:/usr/local/lib" OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include OPENSSL_LIB_DIR=`brew --prefix openssl`/lib cargo build --release
+```
+Note: If you're not using `homebrew` you probably don't need to set the environment variables.
+
+# Compiling on Windows
+
+Note: Make sure that you have the rust nightly GNU ABI toolchain installed with rustup rather than the MSVC ABI. You can check this by running `rustup show` and ensure that you grab the GNU ABI toolchain with `rustup install nightly-gnu`
+
+## Installing dependencies
+Follow the instructions at https://msys2.github.io to install `msys` and `mingw`. After that, run the following command from `msys`:
+```bash
+pacman -S git tar mingw-w64-x86_64-openssl mingw-w64-x86_64-SDL2 mingw-w64-x86_64-gcc
+```
+
+## Compiling
+Compile and run:
+```bash
+cargo run --release
+```
+Just compile:
+```bash
+cargo build --release
+```
+
+
 
 Currently requires SDL2, and **beta or nightly** Rust to build.
 


### PR DESCRIPTION
Since https://github.com/Thinkofname/steven/wiki/Compiling-and-or-running is now outdated (such as no longer requiring OpenSSL as of https://github.com/iceiix/steven/issues/2, and using MSVC to build on Windows instead of MinGW as of https://github.com/iceiix/steven/pull/9), add the (modified) install steps in README.md