### PR TITLE
Isolating graphic corruption with NUM_SAMPLES=1 (set multisampling sample count to 0)

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -43,7 +43,7 @@ use std::sync::mpsc;
 const ATLAS_SIZE: usize = 1024;
 
 // TEMP
-const NUM_SAMPLES: i32 = 2;
+const NUM_SAMPLES: i32 = 0;
 
 pub struct Camera {
     pub pos: cgmath::Point3<f64>,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -43,7 +43,7 @@ use std::sync::mpsc;
 const ATLAS_SIZE: usize = 1024;
 
 // TEMP
-const NUM_SAMPLES: i32 = 2;
+const NUM_SAMPLES: i32 = 1;
 
 pub struct Camera {
     pub pos: cgmath::Point3<f64>,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -312,7 +312,6 @@ impl Renderer {
 
         gl::check_framebuffer_status();
         gl::unbind_framebuffer();
-        gl::clear(gl::ClearFlags::Color);
         trans.draw(&self.trans_shader);
 
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -600,7 +600,6 @@ init_shader! {
             required accum => "taccum",
             required revealage => "trevealage",
             required color => "tcolor",
-            required samples => "samples",
         },
     }
 }
@@ -694,7 +693,6 @@ impl TransInfo {
         shader.accum.set_int(0);
         shader.revealage.set_int(1);
         shader.color.set_int(2);
-        shader.samples.set_int(NUM_SAMPLES);
         self.array.bind();
         gl::draw_arrays(gl::TRIANGLES, 0, 6);
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -309,8 +309,6 @@ impl Renderer {
         gl::enable(gl::BLEND);
         gl::depth_mask(false);
         trans.trans.bind();
-        gl::clear_color(0.0, 0.0, 0.0, 1.0);
-        gl::clear(gl::ClearFlags::Color);
         gl::clear_buffer(gl::COLOR, 0, &[0.0, 0.0, 0.0, 1.0]);
         gl::clear_buffer(gl::COLOR, 1, &[0.0, 0.0, 0.0, 0.0]);
         gl::blend_func_separate(gl::ONE_FACTOR, gl::ONE_FACTOR, gl::ZERO_FACTOR, gl::ONE_MINUS_SRC_ALPHA);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -313,7 +313,6 @@ impl Renderer {
         gl::check_framebuffer_status();
         gl::unbind_framebuffer();
         gl::clear(gl::ClearFlags::Color);
-        gl::disable(gl::BLEND);
         trans.draw(&self.trans_shader);
 
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -292,8 +292,6 @@ impl Renderer {
         gl::active_texture(0);
         self.gl_texture.bind(gl::TEXTURE_2D_ARRAY);
 
-        gl::enable(gl::MULTISAMPLE);
-
         let time_offset = self.sky_offset * 0.9;
         gl::clear_color(
              (122.0 / 255.0) * time_offset,
@@ -328,7 +326,6 @@ impl Renderer {
         gl::enable(gl::DEPTH_TEST);
         gl::depth_mask(true);
         gl::blend_func(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
-        gl::disable(gl::MULTISAMPLE);
 
         gl::check_gl_error();
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -289,7 +289,6 @@ impl Renderer {
 
         gl::active_texture(0);
         self.gl_texture.bind(gl::TEXTURE_2D_ARRAY);
-
         gl::clear_color(
              (122.0 / 255.0),
              (165.0 / 255.0),
@@ -304,7 +303,6 @@ impl Renderer {
         gl::check_framebuffer_status();
         gl::unbind_framebuffer();
         trans.draw(&self.trans_shader);
-
 
         gl::check_gl_error();
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -619,9 +619,9 @@ impl TransInfo {
         main.bind();
 
         let fb_color = gl::Texture::new();
-        fb_color.bind(gl::TEXTURE_2D);
-        fb_color.image_2d_ex(gl::TEXTURE_2D, 0, width, height, gl::RGBA8, gl::RGBA, gl::UNSIGNED_BYTE, None);
-        main.texture_2d(gl::COLOR_ATTACHMENT_0, gl::TEXTURE_2D, &fb_color, 0);
+        fb_color.bind(gl::TEXTURE_2D_MULTISAMPLE);
+        fb_color.image_2d_sample(gl::TEXTURE_2D_MULTISAMPLE, NUM_SAMPLES, width, height, gl::RGBA8, false);
+        main.texture_2d(gl::COLOR_ATTACHMENT_0, gl::TEXTURE_2D_MULTISAMPLE, &fb_color, 0);
 
         gl::check_framebuffer_status();
 
@@ -655,7 +655,7 @@ impl TransInfo {
 
     fn draw(&mut self, shader: &TransShader) {
         gl::active_texture(0);
-        self.fb_color.bind(gl::TEXTURE_2D);
+        self.fb_color.bind(gl::TEXTURE_2D_MULTISAMPLE);
 
         shader.program.use_program();
         shader.color.set_int(0);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -318,16 +318,6 @@ impl Renderer {
         gl::clear_buffer(gl::COLOR, 1, &[0.0, 0.0, 0.0, 0.0]);
         gl::blend_func_separate(gl::ONE_FACTOR, gl::ONE_FACTOR, gl::ZERO_FACTOR, gl::ONE_MINUS_SRC_ALPHA);
 
-        for (pos, info) in world.get_render_list().into_iter().rev() {
-            if let Some(trans) = info.trans.as_ref() {
-                if trans.count > 0 {
-                    self.chunk_shader_alpha.offset.set_int3(pos.0, pos.1 * 4096, pos.2);
-                    trans.array.bind();
-                    gl::draw_elements(gl::TRIANGLES, trans.count as i32, self.element_buffer_type, 0);
-                }
-            }
-        }
-
         gl::check_framebuffer_status();
         gl::unbind_framebuffer();
         gl::disable(gl::DEPTH_TEST);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -579,7 +579,6 @@ impl Renderer {
 struct TransInfo {
     main: gl::Framebuffer,
     fb_color: gl::Texture,
-    _fb_depth: gl::Texture,
     trans: gl::Framebuffer,
     _depth: gl::Texture,
 
@@ -624,10 +623,6 @@ impl TransInfo {
         fb_color.image_2d_sample(gl::TEXTURE_2D_MULTISAMPLE, NUM_SAMPLES, width, height, gl::RGBA8, false);
         main.texture_2d(gl::COLOR_ATTACHMENT_0, gl::TEXTURE_2D_MULTISAMPLE, &fb_color, 0);
 
-        let fb_depth = gl::Texture::new();
-        fb_depth.bind(gl::TEXTURE_2D_MULTISAMPLE);
-        fb_depth.image_2d_sample(gl::TEXTURE_2D_MULTISAMPLE, NUM_SAMPLES, width, height, gl::DEPTH_COMPONENT24, false);
-        main.texture_2d(gl::DEPTH_ATTACHMENT, gl::TEXTURE_2D_MULTISAMPLE, &fb_depth, 0);
         gl::check_framebuffer_status();
 
         gl::unbind_framebuffer();
@@ -650,7 +645,6 @@ impl TransInfo {
         TransInfo {
             main,
             fb_color,
-            _fb_depth: fb_depth,
             trans,
             _depth: trans_depth,
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -330,8 +330,6 @@ impl Renderer {
         gl::blend_func(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
         gl::disable(gl::MULTISAMPLE);
 
-        self.ui.tick(width, height);
-
         gl::check_gl_error();
 
         self.frame_id = self.frame_id.wrapping_add(1);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -42,9 +42,6 @@ use std::sync::mpsc;
 
 const ATLAS_SIZE: usize = 1024;
 
-// TEMP
-const NUM_SAMPLES: i32 = 1;
-
 pub struct Camera {
     pub pos: cgmath::Point3<f64>,
     pub yaw: f64,
@@ -618,7 +615,7 @@ impl TransInfo {
 
         let fb_color = gl::Texture::new();
         fb_color.bind(gl::TEXTURE_2D_MULTISAMPLE);
-        fb_color.image_2d_sample(gl::TEXTURE_2D_MULTISAMPLE, NUM_SAMPLES, width, height, gl::RGBA8, false);
+        fb_color.image_2d_sample(gl::TEXTURE_2D_MULTISAMPLE, 0, width, height, gl::RGBA8, false);
         main.texture_2d(gl::COLOR_ATTACHMENT_0, gl::TEXTURE_2D_MULTISAMPLE, &fb_color, 0);
 
         gl::check_framebuffer_status();

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -619,9 +619,9 @@ impl TransInfo {
         main.bind();
 
         let fb_color = gl::Texture::new();
-        fb_color.bind(gl::TEXTURE_2D_MULTISAMPLE);
-        fb_color.image_2d_sample(gl::TEXTURE_2D_MULTISAMPLE, NUM_SAMPLES, width, height, gl::RGBA8, false);
-        main.texture_2d(gl::COLOR_ATTACHMENT_0, gl::TEXTURE_2D_MULTISAMPLE, &fb_color, 0);
+        fb_color.bind(gl::TEXTURE_2D);
+        fb_color.image_2d_ex(gl::TEXTURE_2D, 0, width, height, gl::RGBA8, gl::RGBA, gl::UNSIGNED_BYTE, None);
+        main.texture_2d(gl::COLOR_ATTACHMENT_0, gl::TEXTURE_2D, &fb_color, 0);
 
         gl::check_framebuffer_status();
 
@@ -655,7 +655,7 @@ impl TransInfo {
 
     fn draw(&mut self, shader: &TransShader) {
         gl::active_texture(0);
-        self.fb_color.bind(gl::TEXTURE_2D_MULTISAMPLE);
+        self.fb_color.bind(gl::TEXTURE_2D);
 
         shader.program.use_program();
         shader.color.set_int(0);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -620,8 +620,7 @@ impl TransInfo {
 
         let fb_color = gl::Texture::new();
         fb_color.bind(gl::TEXTURE_2D);
-let data = vec![100; (width as usize) * (height as usize) * 4];
-        fb_color.image_2d_ex(gl::TEXTURE_2D, 0, width, height, gl::RGBA8, gl::RGBA, gl::UNSIGNED_BYTE, Some(&data));
+        fb_color.image_2d_ex(gl::TEXTURE_2D, 0, width, height, gl::RGBA8, gl::RGBA, gl::UNSIGNED_BYTE, None);
         main.texture_2d(gl::COLOR_ATTACHMENT_0, gl::TEXTURE_2D, &fb_color, 0);
 
         gl::check_framebuffer_status();

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -284,8 +284,6 @@ impl Renderer {
     }
 
     pub fn tick(&mut self, world: &mut world::World, delta: f64, width: u32, height: u32) {
-        self.update_textures(delta);
-
         let trans = self.trans.as_mut().unwrap();
         trans.main.bind();
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -306,7 +306,6 @@ impl Renderer {
             gl::ClearFlags::Depth, gl::NEAREST
         );
 
-        gl::depth_mask(false);
         trans.trans.bind();
         gl::clear_buffer(gl::COLOR, 0, &[0.0, 0.0, 0.0, 1.0]);
         gl::clear_buffer(gl::COLOR, 1, &[0.0, 0.0, 0.0, 0.0]);
@@ -319,7 +318,6 @@ impl Renderer {
         trans.draw(&self.trans_shader);
 
         gl::enable(gl::DEPTH_TEST);
-        gl::depth_mask(true);
 
         gl::check_gl_error();
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -581,8 +581,6 @@ struct TransInfo {
     fb_color: gl::Texture,
     _fb_depth: gl::Texture,
     trans: gl::Framebuffer,
-    accum: gl::Texture,
-    revealage: gl::Texture,
     _depth: gl::Texture,
 
     array: gl::VertexArray,
@@ -597,8 +595,6 @@ init_shader! {
             required position => "aPosition",
         },
         uniform = {
-            required accum => "taccum",
-            required revealage => "trevealage",
             required color => "tcolor",
         },
     }
@@ -609,20 +605,6 @@ impl TransInfo {
         let trans = gl::Framebuffer::new();
         trans.bind();
 
-        let accum = gl::Texture::new();
-        accum.bind(gl::TEXTURE_2D);
-        accum.image_2d_ex(gl::TEXTURE_2D, 0, width, height, gl::RGBA16F, gl::RGBA, gl::FLOAT, None);
-        accum.set_parameter(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::LINEAR);
-        accum.set_parameter(gl::TEXTURE_2D, gl::TEXTURE_MAX_LEVEL, gl::LINEAR);
-        trans.texture_2d(gl::COLOR_ATTACHMENT_0, gl::TEXTURE_2D, &accum, 0);
-
-        let revealage = gl::Texture::new();
-        revealage.bind(gl::TEXTURE_2D);
-        revealage.image_2d_ex(gl::TEXTURE_2D, 0, width, height, gl::R16F, gl::RED, gl::FLOAT, None);
-        revealage.set_parameter(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::LINEAR);
-        revealage.set_parameter(gl::TEXTURE_2D, gl::TEXTURE_MAX_LEVEL, gl::LINEAR);
-        trans.texture_2d(gl::COLOR_ATTACHMENT_1, gl::TEXTURE_2D, &revealage, 0);
-
         let trans_depth = gl::Texture::new();
         trans_depth.bind(gl::TEXTURE_2D);
         trans_depth.image_2d_ex(gl::TEXTURE_2D, 0, width, height, gl::DEPTH_COMPONENT24, gl::DEPTH_COMPONENT, gl::UNSIGNED_BYTE, None);
@@ -631,8 +613,6 @@ impl TransInfo {
         trans.texture_2d(gl::DEPTH_ATTACHMENT, gl::TEXTURE_2D, &trans_depth, 0);
 
         chunk_shader.program.use_program();
-        gl::bind_frag_data_location(&chunk_shader.program, 0, "accum");
-        gl::bind_frag_data_location(&chunk_shader.program, 1, "revealage");
         gl::check_framebuffer_status();
         gl::draw_buffers(&[gl::COLOR_ATTACHMENT_0, gl::COLOR_ATTACHMENT_1]);
 
@@ -672,8 +652,6 @@ impl TransInfo {
             fb_color,
             _fb_depth: fb_depth,
             trans,
-            accum,
-            revealage,
             _depth: trans_depth,
 
             array,
@@ -683,16 +661,10 @@ impl TransInfo {
 
     fn draw(&mut self, shader: &TransShader) {
         gl::active_texture(0);
-        self.accum.bind(gl::TEXTURE_2D);
-        gl::active_texture(1);
-        self.revealage.bind(gl::TEXTURE_2D);
-        gl::active_texture(2);
         self.fb_color.bind(gl::TEXTURE_2D_MULTISAMPLE);
 
         shader.program.use_program();
-        shader.accum.set_int(0);
-        shader.revealage.set_int(1);
-        shader.color.set_int(2);
+        shader.color.set_int(0);
         self.array.bind();
         gl::draw_arrays(gl::TRIANGLES, 0, 6);
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -306,12 +306,10 @@ impl Renderer {
             gl::ClearFlags::Depth, gl::NEAREST
         );
 
-        gl::enable(gl::BLEND);
         gl::depth_mask(false);
         trans.trans.bind();
         gl::clear_buffer(gl::COLOR, 0, &[0.0, 0.0, 0.0, 1.0]);
         gl::clear_buffer(gl::COLOR, 1, &[0.0, 0.0, 0.0, 0.0]);
-        gl::blend_func_separate(gl::ONE_FACTOR, gl::ONE_FACTOR, gl::ZERO_FACTOR, gl::ONE_MINUS_SRC_ALPHA);
 
         gl::check_framebuffer_status();
         gl::unbind_framebuffer();
@@ -322,7 +320,6 @@ impl Renderer {
 
         gl::enable(gl::DEPTH_TEST);
         gl::depth_mask(true);
-        gl::blend_func(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
 
         gl::check_gl_error();
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -303,44 +303,6 @@ impl Renderer {
         );
         gl::clear(gl::ClearFlags::Color | gl::ClearFlags::Depth);
 
-        // Chunk rendering
-        self.chunk_shader.program.use_program();
-
-        self.chunk_shader.perspective_matrix.set_matrix4(&self.perspective_matrix);
-        self.chunk_shader.camera_matrix.set_matrix4(&self.camera_matrix);
-        self.chunk_shader.texture.set_int(0);
-        self.chunk_shader.light_level.set_float(self.light_level);
-        self.chunk_shader.sky_offset.set_float(self.sky_offset);
-
-        for (pos, info) in world.get_render_list() {
-            if let Some(solid) = info.solid.as_ref() {
-                if solid.count > 0 {
-                    self.chunk_shader.offset.set_int3(pos.0, pos.1 * 4096, pos.2);
-                    solid.array.bind();
-                    gl::draw_elements(gl::TRIANGLES, solid.count as i32, self.element_buffer_type, 0);
-                }
-            }
-        }
-
-        // Line rendering
-        // Model rendering
-        self.model.draw(&self.frustum, &self.perspective_matrix, &self.camera_matrix, self.light_level, self.sky_offset);
-        if world.copy_cloud_heightmap(&mut self.clouds.heightmap_data) {
-            self.clouds.dirty = true;
-        }
-        self.clouds.draw(&self.camera.pos, &self.perspective_matrix, &self.camera_matrix, self.light_level, self.sky_offset, delta);
-
-        // Trans chunk rendering
-        self.chunk_shader_alpha.program.use_program();
-        self.chunk_shader_alpha.perspective_matrix.set_matrix4(&self.perspective_matrix);
-        self.chunk_shader_alpha.camera_matrix.set_matrix4(&self.camera_matrix);
-        self.chunk_shader_alpha.texture.set_int(0);
-        self.chunk_shader_alpha.light_level.set_float(self.light_level);
-        self.chunk_shader_alpha.sky_offset.set_float(self.sky_offset);
-
-        // Copy the depth buffer
-        trans.main.bind_read();
-        trans.trans.bind_draw();
         gl::blit_framebuffer(
             0, 0, width as i32, height as i32,
             0, 0, width as i32, height as i32,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -297,13 +297,6 @@ impl Renderer {
              1.0
         );
         gl::clear(gl::ClearFlags::Color | gl::ClearFlags::Depth);
-
-        gl::blit_framebuffer(
-            0, 0, width as i32, height as i32,
-            0, 0, width as i32, height as i32,
-            gl::ClearFlags::Depth, gl::NEAREST
-        );
-
         trans.trans.bind();
         gl::clear_buffer(gl::COLOR, 0, &[0.0, 0.0, 0.0, 1.0]);
         gl::clear_buffer(gl::COLOR, 1, &[0.0, 0.0, 0.0, 0.0]);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -292,11 +292,10 @@ impl Renderer {
         gl::active_texture(0);
         self.gl_texture.bind(gl::TEXTURE_2D_ARRAY);
 
-        let time_offset = self.sky_offset * 0.9;
         gl::clear_color(
-             (122.0 / 255.0) * time_offset,
-             (165.0 / 255.0) * time_offset,
-             (247.0 / 255.0) * time_offset,
+             (122.0 / 255.0),
+             (165.0 / 255.0),
+             (247.0 / 255.0),
              1.0
         );
         gl::clear(gl::ClearFlags::Color | gl::ClearFlags::Depth);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -312,12 +312,10 @@ impl Renderer {
 
         gl::check_framebuffer_status();
         gl::unbind_framebuffer();
-        gl::disable(gl::DEPTH_TEST);
         gl::clear(gl::ClearFlags::Color);
         gl::disable(gl::BLEND);
         trans.draw(&self.trans_shader);
 
-        gl::enable(gl::DEPTH_TEST);
 
         gl::check_gl_error();
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -620,7 +620,8 @@ impl TransInfo {
 
         let fb_color = gl::Texture::new();
         fb_color.bind(gl::TEXTURE_2D);
-        fb_color.image_2d_ex(gl::TEXTURE_2D, 0, width, height, gl::RGBA8, gl::RGBA, gl::UNSIGNED_BYTE, None);
+let data = vec![100; (width as usize) * (height as usize) * 4];
+        fb_color.image_2d_ex(gl::TEXTURE_2D, 0, width, height, gl::RGBA8, gl::RGBA, gl::UNSIGNED_BYTE, Some(&data));
         main.texture_2d(gl::COLOR_ATTACHMENT_0, gl::TEXTURE_2D, &fb_color, 0);
 
         gl::check_framebuffer_status();

--- a/src/render/shaders/trans_frag.glsl
+++ b/src/render/shaders/trans_frag.glsl
@@ -15,6 +15,7 @@ void main() {
     for (int i = 1; i < samples; i++) {
         col += texelFetch(tcolor, C, i);
     }
+    if (samples != 0)
     col /= float(samples);
 
     float r = accum.a;

--- a/src/render/shaders/trans_frag.glsl
+++ b/src/render/shaders/trans_frag.glsl
@@ -1,4 +1,4 @@
-uniform sampler2DMS tcolor;
+uniform sampler2D tcolor;
 
 out vec4 fragColor;
 

--- a/src/render/shaders/trans_frag.glsl
+++ b/src/render/shaders/trans_frag.glsl
@@ -1,10 +1,28 @@
+uniform sampler2D taccum;
+uniform sampler2D trevealage;
 uniform sampler2DMS tcolor;
+
+uniform int samples;
 
 out vec4 fragColor;
 
 void main() {
     ivec2 C = ivec2(gl_FragCoord.xy);
+    vec4 accum = texelFetch(taccum, C, 0);
+    float aa = texelFetch(trevealage, C, 0).r;
     vec4 col = texelFetch(tcolor, C, 0);
 
-    fragColor = vec4(col.rgb, 0.0);
+    for (int i = 1; i < samples; i++) {
+        col += texelFetch(tcolor, C, i);
+    }
+    col /= float(samples);
+
+    float r = accum.a;
+    accum.a = aa;
+    if (r >= 1.0) {
+        fragColor = vec4(col.rgb, 0.0);
+    } else {
+        vec3 alp = clamp(accum.rgb / clamp(accum.a, 1e-4, 5e4), 0.0, 1.0);
+        fragColor = vec4(col.rgb * r  + alp * (1.0 - r), 0.0);
+    }
 }

--- a/src/render/shaders/trans_frag.glsl
+++ b/src/render/shaders/trans_frag.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D tcolor;
+uniform sampler2DMS tcolor;
 
 out vec4 fragColor;
 

--- a/src/render/shaders/trans_frag.glsl
+++ b/src/render/shaders/trans_frag.glsl
@@ -1,13 +1,9 @@
-uniform sampler2D taccum;
-uniform sampler2D trevealage;
 uniform sampler2DMS tcolor;
 
 out vec4 fragColor;
 
 void main() {
     ivec2 C = ivec2(gl_FragCoord.xy);
-    vec4 accum = texelFetch(taccum, C, 0);
-    float aa = texelFetch(trevealage, C, 0).r;
     vec4 col = texelFetch(tcolor, C, 0);
 
     fragColor = vec4(col.rgb, 0.0);

--- a/src/render/shaders/trans_frag.glsl
+++ b/src/render/shaders/trans_frag.glsl
@@ -2,8 +2,6 @@ uniform sampler2D taccum;
 uniform sampler2D trevealage;
 uniform sampler2DMS tcolor;
 
-uniform int samples;
-
 out vec4 fragColor;
 
 void main() {
@@ -11,11 +9,6 @@ void main() {
     vec4 accum = texelFetch(taccum, C, 0);
     float aa = texelFetch(trevealage, C, 0).r;
     vec4 col = texelFetch(tcolor, C, 0);
-
-    for (int i = 1; i < samples; i++) {
-        col += texelFetch(tcolor, C, i);
-    }
-    col /= float(samples);
 
     float r = accum.a;
     accum.a = aa;
@@ -25,4 +18,5 @@ void main() {
         vec3 alp = clamp(accum.rgb / clamp(accum.a, 1e-4, 5e4), 0.0, 1.0);
         fragColor = vec4(col.rgb * r  + alp * (1.0 - r), 0.0);
     }
+
 }

--- a/src/render/shaders/trans_frag.glsl
+++ b/src/render/shaders/trans_frag.glsl
@@ -10,13 +10,5 @@ void main() {
     float aa = texelFetch(trevealage, C, 0).r;
     vec4 col = texelFetch(tcolor, C, 0);
 
-    float r = accum.a;
-    accum.a = aa;
-    if (r >= 1.0) {
-        fragColor = vec4(col.rgb, 0.0);
-    } else {
-        vec3 alp = clamp(accum.rgb / clamp(accum.a, 1e-4, 5e4), 0.0, 1.0);
-        fragColor = vec4(col.rgb * r  + alp * (1.0 - r), 0.0);
-    }
-
+    fragColor = vec4(col.rgb, 0.0);
 }


### PR DESCRIPTION
Attempting to build a reduced test for https://github.com/Thinkofname/steven/issues/74

Part of https://github.com/iceiix/steven/issues/25