### PR TITLE
Use size() instead of drawable_size() to fix scaling/offset on HDPI M295X (#22)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -169,7 +169,7 @@ fn main() {
     let sdl = sdl2::init().unwrap();
     let sdl_video = sdl.video().unwrap();
     let window = sdl2::video::WindowBuilder::new(&sdl_video, "Steven", 854, 480)
-                            .allow_highdpi()
+                            //.allow_highdpi()
                             .opengl()
                             .resizable()
                             .build()

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,6 +223,12 @@ fn main() {
         last_frame = now;
         let delta = (diff.subsec_nanos() as f64) / frame_time;
         let (width, height) = window.drawable_size();
+println!("drawable_size = {}x{}", width, height);
+let (window_width, window_height) = window.size();
+println!("size = {}x{}", window_width, window_height);
+let (scale_x, scale_y) = (width / window_width, height / window_height);
+println!("scale = {}x{}", scale_x, scale_y);
+//game.renderer.set_scale(scale_x, scale_y); // only for 2D sdl2::render
 
         let version = {
             let mut res = game.resource_manager.write().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,7 +223,7 @@ fn main() {
         let diff = now.duration_since(last_frame);
         last_frame = now;
         let delta = (diff.subsec_nanos() as f64) / frame_time;
-        let (width, height) = window.drawable_size();
+        let (width, height) = window.size();
 
         let version = {
             let mut res = game.resource_manager.write().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,12 +224,6 @@ fn main() {
         last_frame = now;
         let delta = (diff.subsec_nanos() as f64) / frame_time;
         let (width, height) = window.drawable_size();
-println!("drawable_size = {}x{}", width, height);
-let (window_width, window_height) = window.size();
-println!("size = {}x{}", window_width, window_height);
-let (scale_x, scale_y) = (width / window_width, height / window_height);
-println!("scale = {}x{}", scale_x, scale_y);
-//game.renderer.set_scale(scale_x, scale_y); // only for 2D sdl2::render
 
         let version = {
             let mut res = game.resource_manager.write().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,7 @@ fn main() {
                             .build()
                             .expect("Could not create sdl window.");
     sdl2::hint::set_with_priority("SDL_MOUSE_RELATIVE_MODE_WARP", "1", &sdl2::hint::Hint::Override);
+    //sdl2::hint::set_with_priority("SDL_VIDEO_HIGHDPI_DISABLED", "1", &sdl2::hint::Hint::Override);
     let gl_attr = sdl_video.gl_attr();
     gl_attr.set_stencil_size(0);
     gl_attr.set_depth_size(24);

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,7 @@ fn main() {
     let sdl = sdl2::init().unwrap();
     let sdl_video = sdl.video().unwrap();
     let window = sdl2::video::WindowBuilder::new(&sdl_video, "Steven", 854, 480)
+                            .allow_highdpi()
                             .opengl()
                             .resizable()
                             .build()

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -252,7 +252,6 @@ impl Renderer {
         }
 
         if self.height != height || self.width != width {
-println!("resized from {}x{} to {}x{}", self.height, self.width, height, width);
             self.width = width;
             self.height = height;
             gl::viewport(0, 0, width as i32, height as i32);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -252,6 +252,7 @@ impl Renderer {
         }
 
         if self.height != height || self.width != width {
+println!("resized from {}x{} to {}x{}", self.height, self.width, height, width);
             self.width = width;
             self.height = height;
             gl::viewport(0, 0, width as i32, height as i32);


### PR DESCRIPTION
https://github.com/iceiix/steven/issues/22 Wrong GUI offsets on AMD Radeon R9 M295X