### PR TITLE
1.11.2 (316) protocol update

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -36,7 +36,7 @@ use flate2::Compression;
 use std::time::{Instant, Duration};
 use crate::shared::Position;
 
-pub const SUPPORTED_PROTOCOL: i32 = 315;
+pub const SUPPORTED_PROTOCOL: i32 = 316;
 
 
 /// Helper macro for defining packets

--- a/src/protocol/packet.rs
+++ b/src/protocol/packet.rs
@@ -751,7 +751,7 @@ state_packets!(
                 field flags: Option<u8> = when(|p: &Teams| p.mode == 0 || p.mode == 2),
                 field name_tag_visibility: Option<String> = when(|p: &Teams| p.mode == 0 || p.mode == 2),
                 field collision_rule: Option<String> = when(|p: &Teams| p.mode == 0 || p.mode == 2),
-                field color: Option<u8> = when(|p: &Teams| p.mode == 0 || p.mode == 2),
+                field color: Option<i8> = when(|p: &Teams| p.mode == 0 || p.mode == 2),
                 field players: Option<LenPrefixed<VarInt, String>> = when(|p: &Teams| p.mode == 0 || p.mode == 3 || p.mode == 4),
             }
             /// UpdateScore is used to update or remove an item from a scoreboard

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -30,8 +30,8 @@ use zip;
 use crate::types::hash::FNVHash;
 use crate::ui;
 
-const RESOURCES_VERSION: &str = "1.11";
-const VANILLA_CLIENT_URL: &str = "https://launcher.mojang.com/mc/game/1.11/client/780e46b3a96091a7f42c028c615af45974629072/client.jar";
+const RESOURCES_VERSION: &str = "1.11.2";
+const VANILLA_CLIENT_URL: &str = "https://launcher.mojang.com/mc/game/1.11.2/client/db5aa600f0b0bf508aaf579509b345c4e34087be/client.jar";
 const ASSET_VERSION: &str = "1.11";
 const ASSET_INDEX_URL: &str = "https://launchermeta.mojang.com/mc/assets/1.11/e02b8fba4390e173057895c56ecc91e3ce3bbd40/1.11.json";
 


### PR DESCRIPTION
Only a minor update, -1 now indicates no color, so changed u8 to i8:

https://wiki.vg/Protocol_History#16w50a
https://wiki.vg/index.php?title=Protocol&diff=8543&oldid=8405
https://wiki.vg/index.php?title=Protocol&oldid=8543

and updated version numbers. 1.11.2 uses the same 1.11 assets, which can
be found by looking up 1.11.2 in:

https://launchermeta.mojang.com/mc/game/version_manifest.json
https://launchermeta.mojang.com/v1/packages/6bd228727ed48bd7ac7bdc0088587dad0fb7c02b/1.11.2.json