### PR TITLE
Add new blocks up to 1.12

### DIFF
--- a/blocks/Cargo.lock
+++ b/blocks/Cargo.lock
@@ -1,35 +1,67 @@
-[root]
-name = "steven_blocks"
-version = "0.0.1"
+[[package]]
+name = "approx"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bit-set"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cgmath 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "collision 0.5.1 (git+https://github.com/TheUnnamedDude/collision-rs?rev=f80825e)",
- "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "steven_shared 0.0.1",
+ "bit-vec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cgmath"
-version = "0.7.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "collision"
-version = "0.5.1"
-source = "git+https://github.com/TheUnnamedDude/collision-rs?rev=f80825e#f80825eca687ff1053ff492e54fa782944c9cf6b"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cgmath 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-set 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazy_static"
-version = "0.1.15"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -47,6 +79,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,11 +116,133 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "smallvec"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "steven_blocks"
+version = "0.0.1"
+dependencies = [
+ "cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "collision 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "steven_shared 0.0.1",
+]
+
+[[package]]
 name = "steven_shared"
 version = "0.0.1"
 
+[[package]]
+name = "syn"
+version = "0.15.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
+"checksum bit-set 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f1efcc46c18245a69c38fcc5cc650f16d3a59d034f3106e9ed63748f695730a"
+"checksum bit-vec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4440d5cb623bb7390ae27fec0bb6c61111969860f8e3ae198bfa0663645e67cf"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"
+"checksum collision 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "928b2092661bb4cd6f5e5a39c639ac6553a1e69750fab6de2edb86e2304f9eaa"
+"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+"checksum libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "95ca44454e7cfe7f8a2095a41a10c79d96a177c0b1672cbf1a30d901a9c16ee5"
+"checksum num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "be45b3e341522564415a07118d7cf44896d0919e7a1bb21d59ad82af48256324"
+"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
+"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
+"checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
+"checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
+"checksum rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "9cf81518cd579f8a9c58c0a71328bdb9be15c754181261da82583092dc8a7ff0"
+"checksum serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "6fa52f19aee12441d5ad11c9a00459122bd8f98707cadf9778c540674f1935b6"
+"checksum serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "96a7f9496ac65a2db5929afa087b54f8fc5008dcfbe48a8874ed20049b0d6154"
+"checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
+"checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -3795,6 +3795,233 @@ define_blocks! {
         model { ("minecraft", "observer") },
         variant format!("facing={},powered={}", facing.as_string(), powered),
     }
+    // TODO: Shulker box textures (1.11+), since there is no model, we use wool for now
+    // The textures should be built from textures/blocks/shulker_top_<color>.png
+    // and textures/entity/shulker/shulker_<color>.png
+    WhiteShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "white_wool") },
+    }
+    OrangeShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "orange_wool") },
+    }
+    MagentaShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "magenta_wool") },
+    }
+    LightBlueShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "light_blue_wool") },
+    }
+    YellowShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "yellow_wool") },
+    }
+    LimeShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "lime_wool") },
+    }
+    PinkShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "pink_wool") },
+    }
+    GrayShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "gray_wool") },
+    }
+    LightGrayShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "light_gray_wool") },
+    }
+    CyanShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "cyan_wool") },
+    }
+    PurpleShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "purple_wool") },
+    }
+    BlueShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "blue_wool") },
+    }
+    BrownShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "brown_wool") },
+    }
+    GreenShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "green_wool") },
+    }
+    RedShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "red_wool") },
+    }
+    BlackShulkerBox {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.index()),
+        model { ("minecraft", "black_wool") },
+    }
 
     Missing {
         props {},

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -3769,6 +3769,17 @@ define_blocks! {
         model { ("minecraft", "bone_block") },
         variant format!("axis={}", axis.as_string()),
     }
+    StructureVoid {
+        props {},
+        material material::Material {
+            collidable: false,
+            .. material::INVISIBLE
+        },
+        model { ("minecraft", "structure_void") },
+        // TODO: a small hit box but no collision
+        collision vec![],
+    }
+
     Missing {
         props {},
         data None::<usize>,

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -3761,6 +3761,14 @@ define_blocks! {
         props {},
         model { ("minecraft", "red_nether_brick") },
     }
+    BoneBlock {
+        props {
+            axis: Axis = [Axis::Y, Axis::Z, Axis::X],
+        },
+        data Some(axis.index() << 2),
+        model { ("minecraft", "bone_block") },
+        variant format!("axis={}", axis.as_string()),
+    }
     Missing {
         props {},
         data None::<usize>,

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -4022,6 +4022,214 @@ define_blocks! {
         data Some(facing.index()),
         model { ("minecraft", "black_wool") },
     }
+    WhiteGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "white_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    OrangeGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "orange_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    MagentaGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "magenta_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    LightBlueGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "light_blue_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    YellowGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "yellow_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    LimeGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "lime_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    PinkGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "pink_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    GrayGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "gray_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    LightGrayGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "silver_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    CyanGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "cyan_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    PurpleGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "purple_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    BlueGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "blue_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    BrownGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "brown_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    GreenGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "green_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    RedGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "red_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
+    BlackGlazedTerracotta {
+        props {
+            facing: Direction = [
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+        },
+        data Some(facing.horizontal_index()),
+        model { ("minecraft", "black_glazed_terracotta") },
+        variant format!("facing={}", facing.as_string()),
+    }
 
     Missing {
         props {},

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -4278,6 +4278,29 @@ define_blocks! {
         data Some(color.data()),
         model { ("minecraft", format!("{}_concrete_powder", color.as_string()) ) },
     }
+    Missing253 {
+        props {},
+        data None::<usize>,
+        model { ("steven", "missing_block") },
+    }
+    Missing254 {
+        props {},
+        data None::<usize>,
+        model { ("steven", "missing_block") },
+    }
+    StructureBlock {
+        props {
+            mode: StructureBlockMode = [
+                StructureBlockMode::Save,
+                StructureBlockMode::Load,
+                StructureBlockMode::Corner,
+                StructureBlockMode::Data
+            ],
+        },
+        data Some(mode.data()),
+        model { ("minecraft", "structure_block") },
+        variant format!("mode={}", mode.as_string()),
+    }
 
     Missing {
         props {},
@@ -5562,6 +5585,34 @@ impl StairShape {
             StairShape::InnerRight => "inner_right",
             StairShape::OuterLeft => "outer_left",
             StairShape::OuterRight => "outer_right",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum StructureBlockMode {
+    Save,
+    Load,
+    Corner,
+    Data,
+}
+
+impl StructureBlockMode {
+    pub fn data(self) -> usize {
+        match self {
+            StructureBlockMode::Save => 0,
+            StructureBlockMode::Load => 1,
+            StructureBlockMode::Corner => 2,
+            StructureBlockMode::Data => 3,
+        }
+    }
+
+    pub fn as_string(self) -> &'static str {
+        match self {
+            StructureBlockMode::Save => "save",
+            StructureBlockMode::Load => "load",
+            StructureBlockMode::Corner => "corner",
+            StructureBlockMode::Data => "data",
         }
     }
 }

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -3749,6 +3749,10 @@ define_blocks! {
         props {},
         model { ("minecraft", "frosted_ice") },
     }
+    MagmaBlock {
+        props {},
+        model { ("minecraft", "magma") },
+    }
     Missing {
         props {},
         data None::<usize>,

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -4230,6 +4230,54 @@ define_blocks! {
         model { ("minecraft", "black_glazed_terracotta") },
         variant format!("facing={}", facing.as_string()),
     }
+    Concrete {
+        props {
+            color: ColoredVariant = [
+                ColoredVariant::White,
+                ColoredVariant::Orange,
+                ColoredVariant::Magenta,
+                ColoredVariant::LightBlue,
+                ColoredVariant::Yellow,
+                ColoredVariant::Lime,
+                ColoredVariant::Pink,
+                ColoredVariant::Gray,
+                ColoredVariant::Silver,
+                ColoredVariant::Cyan,
+                ColoredVariant::Purple,
+                ColoredVariant::Blue,
+                ColoredVariant::Brown,
+                ColoredVariant::Green,
+                ColoredVariant::Red,
+                ColoredVariant::Black
+            ],
+        },
+        data Some(color.data()),
+        model { ("minecraft", format!("{}_concrete", color.as_string()) ) },
+    }
+    ConcretePowder {
+        props {
+            color: ColoredVariant = [
+                ColoredVariant::White,
+                ColoredVariant::Orange,
+                ColoredVariant::Magenta,
+                ColoredVariant::LightBlue,
+                ColoredVariant::Yellow,
+                ColoredVariant::Lime,
+                ColoredVariant::Pink,
+                ColoredVariant::Gray,
+                ColoredVariant::Silver,
+                ColoredVariant::Cyan,
+                ColoredVariant::Purple,
+                ColoredVariant::Blue,
+                ColoredVariant::Brown,
+                ColoredVariant::Green,
+                ColoredVariant::Red,
+                ColoredVariant::Black
+            ],
+        },
+        data Some(color.data()),
+        model { ("minecraft", format!("{}_concrete_powder", color.as_string()) ) },
+    }
 
     Missing {
         props {},

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -3779,6 +3779,22 @@ define_blocks! {
         // TODO: a small hit box but no collision
         collision vec![],
     }
+    Observer {
+        props {
+            facing: Direction = [
+                Direction::Up,
+                Direction::Down,
+                Direction::North,
+                Direction::South,
+                Direction::West,
+                Direction::East
+            ],
+            powered: bool = [false, true],
+        },
+        data Some(facing.index() | (if powered { 0x8 } else { 0x0 })),
+        model { ("minecraft", "observer") },
+        variant format!("facing={},powered={}", facing.as_string(), powered),
+    }
 
     Missing {
         props {},

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -3753,6 +3753,14 @@ define_blocks! {
         props {},
         model { ("minecraft", "magma") },
     }
+    NetherWartBlock {
+        props {},
+        model { ("minecraft", "nether_wart_block") },
+    }
+    RedNetherBrick {
+        props {},
+        model { ("minecraft", "red_nether_brick") },
+    }
     Missing {
         props {},
         data None::<usize>,


### PR DESCRIPTION
https://github.com/iceiix/steven/pull/40 added 1.12.2 protocol support (340), but there are new blocks too that should be added:

https://minecraft.gamepedia.com/1.12#Additions
https://minecraft.gamepedia.com/Java_Edition_data_values/Pre-flattening#Block_IDs

- [x] 1.10 blocks (added in https://github.com/iceiix/steven/pull/69)
- [x] Observer
- [x] Shulker boxes
  - [ ] Correct shulker box textures
- [x] Glazed terracottas
- [x] Concrete
- [x] Concrete powder
- [x] Structure block